### PR TITLE
fix: restrict robots.txt crawl rules and add sitemap

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -2,4 +2,8 @@
 
 # Allow crawling of all content
 User-agent: *
-Disallow:
+Disallow: /admin/
+Disallow: /private/
+
+# Sitemap location
+Sitemap: https://example.com/sitemap.xml


### PR DESCRIPTION
## Summary

- Disallow `/admin/` and `/private/` paths from crawlers
- Add `Sitemap` directive pointing to the canonical sitemap URL

Small config-only change — no logic modified.

## Test plan

- [ ] Verify crawlers respect the new `Disallow` rules
- [ ] Confirm sitemap URL resolves correctly in production