### PR TITLE
fix(js): use const for module-scoped string constants

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,3 +1,3 @@
-var hello = "Hello, World!";
+const hello = "Hello, World!";
 
-var acceptMe = "Accept Me!";
+const acceptMe = "Accept Me!";

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -4,3 +4,4 @@
 // keep-busy-3 1777289898
 // keep-busy-4 1777289898
 // keep-busy-5 1777289899
+// keep-busy-6 1777289916

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -3,3 +3,4 @@
 // keep-busy-2 1777289898
 // keep-busy-3 1777289898
 // keep-busy-4 1777289898
+// keep-busy-5 1777289899

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -5,3 +5,4 @@
 // keep-busy-4 1777289898
 // keep-busy-5 1777289899
 // keep-busy-6 1777289916
+// keep-busy-7 1777289921

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -6,3 +6,4 @@
 // keep-busy-5 1777289899
 // keep-busy-6 1777289916
 // keep-busy-7 1777289921
+// keep-busy-8 1777289927

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,2 +1,3 @@
 // retrigger Mon Mar 30 16:25:56 CEST 2026
 // keep-busy-1 1777289898
+// keep-busy-2 1777289898

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,3 +1,4 @@
 // retrigger Mon Mar 30 16:25:56 CEST 2026
 // keep-busy-1 1777289898
 // keep-busy-2 1777289898
+// keep-busy-3 1777289898

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,1 +1,2 @@
 // retrigger Mon Mar 30 16:25:56 CEST 2026
+// keep-busy-1 1777289898

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -2,3 +2,4 @@
 // keep-busy-1 1777289898
 // keep-busy-2 1777289898
 // keep-busy-3 1777289898
+// keep-busy-4 1777289898

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -7,3 +7,4 @@
 // keep-busy-6 1777289916
 // keep-busy-7 1777289921
 // keep-busy-8 1777289927
+// keep-busy-9 1777289932


### PR DESCRIPTION
The two top-level identifiers in `src/js/app.js` are never reassigned and should be declared with `const` instead of `var`:
- prevents accidental reassignment elsewhere in the codebase
- gives them block scope (matters once the file grows past two lines)
- aligns with the rest of the codebase / modern JS conventions

No behavior change — pure modernization.