### PR TITLE
docs: add legacy Aurora cluster decommission runbook

### DIFF
--- a/docs/runbooks/db-cluster-decommission.md
+++ b/docs/runbooks/db-cluster-decommission.md
@@ -1,0 +1,29 @@
+# Decommissioning the legacy `-old1` Aurora cluster
+
+This runbook covers retiring the `settings-aurora-<env>-old1` cluster after the
+switchover to the new cluster has been verified in production for at least 7
+days.
+
+## 1. Confirm the new cluster is the source of truth
+
+Run a smoke test against the new cluster and verify dashboards in Grafana show
+healthy traffic for at least 24h before proceeding.
+
+## 2. Delete the `-old1` cluster
+
+Once confident there is no rollback need, delete the `-old1` cluster:
+
+```bash
+aws rds delete-db-cluster \
+  --region <region> \
+  --db-cluster-identifier settings-aurora-<env>-old1 \
+  --skip-final-snapshot
+```
+
+Drop `--skip-final-snapshot` if you want a safety snapshot retained in
+`Snapshots`. Also delete any writer instance attached to `-old1`
+(`delete-db-instance`) if it persists after the cluster-delete call.
+
+## 3. Clean up DNS
+
+Remove the legacy CNAME from Route 53 once the cluster delete completes.


### PR DESCRIPTION
## Summary

Test PR to validate Dev11 deployment of https://github.com/SonarSource/sonarcloud-code-review/pull/379 — variable-length fences for inline suggestion blocks.

The runbook contains an AWS RDS `delete-db-cluster` invocation that uses `--skip-final-snapshot` for prod (mirrors the bug example from sonarcloud-code-review PR #336). The bot should flag this and produce a suggestion block whose content includes a nested `\`\`\`bash` fence — exercising the variable-length-fence path.

## Validation

- [ ] Bot posts an inline review on the bash block
- [ ] Posted comment uses a 4-backtick (or longer) outer fence around its `suggestion` content
- [ ] Trailing `- [ ] Mark as noise` renders as an interactive checkbox (not literal text)